### PR TITLE
Defined default exposed port to handle VPN traffic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,9 @@ ARG PKG_NAME="v6-boilerplate-py"
 COPY . /app
 RUN pip install /app
 
+# expose a port that may be used for communication to other algorithms via VPN. Default is 8888.
+EXPOSE 8888
+
 ENV PKG_NAME=${PKG_NAME}
 
 # Tell docker to execute `docker_wrapper()` when the image is run.


### PR DESCRIPTION
For VPN communication between the algorithm container and the VPN container we use port 8888 by default. By defining an EXPOSE in the dockerfile this can be set by the algorithm developer. Code to read the EXPOSEd port on the node-side was committed in the `feature/eduvpn-connect` branch in vantage6-node.